### PR TITLE
refactor. getServerSideProps => getStaticProps 변경

### DIFF
--- a/pages/clips/[clips].tsx
+++ b/pages/clips/[clips].tsx
@@ -2,16 +2,15 @@ import React from 'react';
 
 import { css } from '@emotion/react';
 import { dehydrate, QueryClient, useQueries } from '@tanstack/react-query';
-import { GetServerSideProps } from 'next';
+import { GetStaticPaths, GetStaticProps } from 'next';
 
 import ClipCard from 'components/atoms/ClipCard/ClipCard';
 import { getContentById, getUpNext } from 'pages/api/fetchAPI';
 import { DETAIL, QUERY_KEYS, UPNEXT } from 'src/constants';
-import wrapper from 'store/index';
 import { ParamTypes } from 'types/types';
 
-export const getServerSideProps: GetServerSideProps = wrapper.getServerSideProps(() => async (context) => {
-  const param = context.query.clips;
+export const getStaticProps: GetStaticProps = async (context) => {
+  const param = context.params?.clips;
 
   const queryClient = new QueryClient();
 
@@ -19,9 +18,16 @@ export const getServerSideProps: GetServerSideProps = wrapper.getServerSideProps
   await queryClient.prefetchQuery([QUERY_KEYS.GET_UPNEXT], () => getUpNext(param as string));
 
   return {
-    props: { dehydratedState: dehydrate(queryClient), param },
+    props: { dehydratedState: dehydrate(queryClient) },
   };
-});
+};
+
+export const getStaticPaths: GetStaticPaths = async () => {
+  return {
+    paths: [],
+    fallback: 'blocking',
+  };
+};
 
 const Clips = ({ param }: ParamTypes) => {
   const results = useQueries({

--- a/pages/gifs/[gifs].tsx
+++ b/pages/gifs/[gifs].tsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 import { css } from '@emotion/react';
 import { dehydrate, QueryClient, useQueries } from '@tanstack/react-query';
-import { GetServerSideProps } from 'next';
+import { GetStaticProps, GetStaticPaths } from 'next';
 
 import NormalGrid from 'components/modules/Gird/NormalGrid';
 import GifSection from 'components/templates/GifsSection/GifSection';
@@ -12,11 +12,10 @@ import CardLayer from 'layer/CardLayer';
 import CarouselLayer from 'layer/CarouselLayer';
 import { getContentById, getRelatedClips, getRelatedGifs } from 'pages/api/fetchAPI';
 import { CONTENT, GIF, QUERY_KEYS, RELATED_CLIPS, RELATED_GIFS } from 'src/constants';
-import wrapper from 'src/store';
 import { ParamTypes } from 'types/types';
 
-export const getServerSideProps: GetServerSideProps = wrapper.getServerSideProps(() => async (context) => {
-  const param = context.query.gifs;
+export const getStaticProps: GetStaticProps = async (context) => {
+  const param = context.params?.gifs;
 
   const queryClient = new QueryClient();
 
@@ -27,7 +26,14 @@ export const getServerSideProps: GetServerSideProps = wrapper.getServerSideProps
   return {
     props: { dehydratedState: dehydrate(queryClient), param },
   };
-});
+};
+
+export const getStaticPaths: GetStaticPaths = async () => {
+  return {
+    paths: [],
+    fallback: 'blocking',
+  };
+};
 
 const Gifs = ({ param }: ParamTypes) => {
   const results = useQueries({

--- a/pages/menu/[menu].tsx
+++ b/pages/menu/[menu].tsx
@@ -2,18 +2,17 @@ import React from 'react';
 
 import { css } from '@emotion/react';
 import { dehydrate, QueryClient, useQuery } from '@tanstack/react-query';
-import { GetServerSideProps } from 'next';
+import { GetStaticProps } from 'next';
 
 import Header from 'components/atoms/Header/Header';
 import NormalGrid from 'components/modules/Gird/NormalGrid';
 import SidebarBox from 'components/modules/SidebarBox/SidebarBox';
 import { getSearchData } from 'pages/api/fetchAPI';
 import { LARGE_HEADER, QUERY_KEYS, RELATED_GIFS } from 'src/constants';
-import wrapper from 'store/index';
 import { ParamTypes } from 'types/types';
 
-export const getServerSideProps: GetServerSideProps = wrapper.getServerSideProps(() => async (context) => {
-  const param = context.query.menu;
+export const getStaticProps: GetStaticProps = async (context) => {
+  const param = context.params?.menu;
   const queryClient = new QueryClient();
 
   await queryClient.prefetchQuery([QUERY_KEYS.SEARCH_DATA], () => getSearchData(param as string));
@@ -21,7 +20,14 @@ export const getServerSideProps: GetServerSideProps = wrapper.getServerSideProps
   return {
     props: { dehydratedState: dehydrate(queryClient), param },
   };
-});
+};
+
+export const getStaticPaths: GetStaticPaths = async () => {
+  return {
+    paths: [],
+    fallback: 'blocking',
+  };
+};
 
 const Menu = ({ param }: ParamTypes) => {
   const { data: searchData, isSuccess } = useQuery([QUERY_KEYS.SEARCH_DATA], () => getSearchData(param));

--- a/pages/search/[search].tsx
+++ b/pages/search/[search].tsx
@@ -2,18 +2,17 @@ import React, { useEffect } from 'react';
 
 import { css } from '@emotion/react';
 import { dehydrate, QueryClient, useQuery } from '@tanstack/react-query';
-import { GetServerSideProps } from 'next';
+import { GetStaticProps, GetStaticPaths } from 'next';
 
 import Header from 'components/atoms/Header/Header';
 import NormalGrid from 'components/modules/Gird/NormalGrid';
 import { getSearchData } from 'pages/api/fetchAPI';
 import { LARGE_HEADER, QUERY_KEYS } from 'src/constants';
 import { RELATED_GIFS } from 'src/constants';
-import wrapper from 'src/store';
 import { ParamTypes } from 'types/types';
 
-export const getServerSideProps: GetServerSideProps = wrapper.getServerSideProps(() => async (context) => {
-  const param = context.query.search;
+export const getStaticProps: GetStaticProps = async (context) => {
+  const param = context.params?.search;
   const queryClient = new QueryClient();
 
   await queryClient.prefetchQuery([QUERY_KEYS.SEARCH_DATA], () => getSearchData(param as string));
@@ -21,7 +20,14 @@ export const getServerSideProps: GetServerSideProps = wrapper.getServerSideProps
   return {
     props: { dehydratedState: dehydrate(queryClient), param },
   };
-});
+};
+
+export const getStaticPaths: GetStaticPaths = async () => {
+  return {
+    paths: [],
+    fallback: 'blocking',
+  };
+};
 
 const Search = ({ param }: ParamTypes) => {
   const { data: searchData, isSuccess, refetch } = useQuery([QUERY_KEYS.SEARCH_DATA], () => getSearchData(param));


### PR DESCRIPTION
### 작업 개요
github-pages 활용하여 프로젝트 호스팅하던 중 Static HTML이 export 되지 않는 에러 발생
(Vercel 로 배포 했을 때는 문제 없었음)

<img width="1244" alt="Screen Shot 2023-01-25 at 5 05 24 PM" src="https://user-images.githubusercontent.com/34735492/214551381-abaf89e1-6ce6-4ceb-a221-6aa381328fe5.png">
<img width="1250" alt="Screen Shot 2023-01-25 at 5 05 33 PM" src="https://user-images.githubusercontent.com/34735492/214551497-c4325854-56c9-41ba-bbe1-918e05ec2576.png">

### 작업 분류
- [x] 버그 수정
- [ ] 신규 기능
- [ ] 프로젝트 구조 변경

### 작업 상세 내용
- NextJS 는 static HTML을 export 하기 위해 기본적으로 getStaticProps는 지원하지만,  getServerSideProps 를 사용하기 위해서는 Node.js 서버가 필요하다. => getStaticProps 로 코드 리팩토링 및 redux를 사용하면서 사용했던 wrapper 코드 삭제

### 비고
- https://nextjs.org/docs/advanced-features/static-html-export 

### 생각해볼 문제
- Vercel에서는 왜 아무런 문제가 없었는지?
- 정적웹, 동적웹의 좀 더 명확한 개념
- getServerSideProps 와 getStaticProps의 차이
